### PR TITLE
Extend inline-tag allow-list and preserve nested content within allow…

### DIFF
--- a/lib/relaton/render/parse/parse.rb
+++ b/lib/relaton/render/parse/parse.rb
@@ -82,7 +82,12 @@ module Relaton
         end
       end
 
-      ALLOWED_INLINE_TAGS = %w[em strong sub sup a smallcap].freeze
+      ALLOWED_INLINE_TAGS = %w[
+        em eref strong stem sub sup tt underline keyword ruby
+        strike smallcap xref br link hr pagebreak bookmark
+        image index index-xref concept add del span erefstack
+        date fn
+      ].freeze
 
       private
 
@@ -100,12 +105,39 @@ module Relaton
       # output against embedded structural markup (most commonly <title>) in
       # bibliographic text fields, where relaton-bib may surface either form
       # depending on lutaml-model serialisation behaviour.
+      #
+      # Authors embed inline markup either literally (<em>foo</em>) or
+      # entity-encoded (&lt;em&gt;foo&lt;/em&gt;); both are intended as
+      # markup, and downstream template rendering decodes entities anyway
+      # (see HTMLEntities.decode in template.rb), so we normalise the
+      # encoded form to literal up front and let a single Nokogiri-fragment
+      # walk handle both. Elements whose name is in the allow-list are
+      # preserved verbatim with their entire subtree, so wrappers that
+      # legitimately carry block content (notably <fn><p>…</p></fn>)
+      # round-trip intact rather than being shredded one tag at a time.
+      # Disallowed elements are unwrapped (tag dropped, children kept),
+      # recursing first so allowed wrappers nested inside disallowed
+      # wrappers still survive. Nokogiri re-escapes any genuine `<` left in
+      # text positions on serialisation, so plain prose like "5 < 10" is
+      # preserved correctly.
       def sanitise_inline_markup(str)
         blank?(str) and return str
-        allowed = ALLOWED_INLINE_TAGS.join("|")
-        literal = %r{</?(?!(?:#{allowed})\b)[A-Za-z][\w:-]*(?:\s[^>]*)?/?>}
-        encoded = %r{&lt;/?(?!(?:#{allowed})\b)[A-Za-z][\w:-]*(?:\s[^&]*?)?/?&gt;}
-        str.gsub(literal, "").gsub(encoded, "")
+        normalised = str.gsub("&lt;", "<").gsub("&gt;", ">")
+        frag = Nokogiri::XML.fragment(normalised)
+        unwrap_disallowed(frag)
+        save_opts = Nokogiri::XML::Node::SaveOptions::AS_XML |
+                    Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
+        frag.to_xml(encoding: "UTF-8", save_with: save_opts)
+      end
+
+      def unwrap_disallowed(node)
+        node.children.to_a.each do |child|
+          next unless child.element?
+          next if ALLOWED_INLINE_TAGS.include?(child.name)
+
+          unwrap_disallowed(child)
+          child.replace(child.children)
+        end
       end
 
       def wrap_in_esc(obj)

--- a/spec/relaton/general_spec.rb
+++ b/spec/relaton/general_spec.rb
@@ -917,7 +917,31 @@ RSpec.describe Relaton::Render do
       {{ creatornames }} ,_{{role}} ({{date}}) . <em><title>{{ title }}</title></em> ,_{{ edition }} . {{ publisher }} .
     TEMPLATE
     output = <<~OUTPUT
-      <formattedref>ALUFFI, Paolo, ed. (2022). <em><title>Facets of <em>Algebraic</em> alert(1) Geometry</title></em>, 1st edition. Cambridge University <sub>Press</sub>.</formattedref>
+      <formattedref>ALUFFI, Paolo, ed. (2022). <em><title>Facets of <em>Algebraic</em> alert(1) Geometry</title></em>, 1st edition. <span class="x">Cambridge</span> University <sub>Press</sub>.</formattedref>
+    OUTPUT
+    p = Relaton::Render::General
+      .new(template: { book: template }, language: "en")
+    expect(p.render(input)).to be_xml_equivalent_to output
+  end
+
+  it "preserves nested markup inside an allow-listed wrapper such as <fn>" do
+    input = <<~INPUT
+      <bibitem type="book">
+        <title>Facets &lt;fn id="f1"&gt;&lt;p&gt;See &lt;em&gt;note&lt;/em&gt; 1&lt;/p&gt;&lt;/fn&gt; of Algebra</title>
+        <date type="published"><on>2022</on></date>
+        <contributor>
+          <role type="author"/>
+          <person>
+            <name><surname>Test</surname><forename>Author</forename></name>
+          </person>
+        </contributor>
+      </bibitem>
+    INPUT
+    template = <<~TEMPLATE
+      {{ creatornames }}. <em>{{ title }}</em>. {{date}}.
+    TEMPLATE
+    output = <<~OUTPUT
+      <formattedref>TEST, Author. <em>Facets <fn id="f1"><p>See <em>note</em> 1</p></fn> of Algebra</em>. 2022.</formattedref>
     OUTPUT
     p = Relaton::Render::General
       .new(template: { book: template }, language: "en")


### PR DESCRIPTION
…ed tags: https://github.com/relaton/relaton-render/issues/74

The initial six-tag allow-list was too narrow and the per-tag regex shredded legitimate block content inside allowed wrappers (e.g. <fn><p>...</p></fn>). Replace the regex with a Nokogiri-fragment walk that preserves allow-listed subtrees verbatim; widen the allow-list to the full Metanorma inline set. See issue for full narrative.

Fixes https://github.com/relaton/relaton-render/issues/74