### PR TITLE
Restore relaton/support wrapper for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,9 @@ on:
 
 jobs:
   release:
-    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
+    uses: relaton/support/.github/workflows/release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
     secrets:
-      rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
-      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+      rubygems-api-key: ${{ secrets.RELATON_CI_RUBYGEMS_API_KEY }}
 


### PR DESCRIPTION
Bringing `relaton-render`'s release config back into alignment with the `relaton/support` wrapper convention used by every other relaton gem (relaton-bib, relaton-iso, relaton-iec, relaton-bipm, relaton-itu, ...; all currently route through `relaton/support/.github/workflows/release.yml@main`).

## Changes

- `uses:` → `relaton/support/.github/workflows/release.yml@main` (was `metanorma/ci/.github/workflows/rubygems-release.yml@main`)
- `secrets.rubygems-api-key:` → `${{ secrets.RELATON_CI_RUBYGEMS_API_KEY }}` (was `METANORMA_CI_RUBYGEMS_API_KEY`)
- Drop the `pat_token` reference — `relaton/support` does not require or forward it, matching the rest of the relaton org's release path

## Test plan

- [x] PR CI passes
- [x] After merge, dispatch test release on `relaton-render` with `next_version: skip` to verify the wrapper round-trip publishes idempotently

🤖
