### PR TITLE
chore(ci): cimas sync 2026-06-24 — required_ruby_version >= 3.3, automerge v0.16.4 pin, lutaml Makefile (refs metanorma/ci#274 #283 #281 #300)

### DIFF
--- a/relaton-render.gemspec
+++ b/relaton-render.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "canon"


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.